### PR TITLE
수정(Android-Databinding_Configure.md): xml 예시에서 encoding 수정

### DIFF
--- a/_posts/2020-08-10-Android-Databinding_Configure.md
+++ b/_posts/2020-08-10-Android-Databinding_Configure.md
@@ -39,7 +39,7 @@ android {
 코드로 나타내면 다음과 같습니다.  
 
 ```xml
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
     <layout xmlns:android="http://schemas.android.com/apk/res/android">
        <data>
            <variable name="user" type="com.example.User"/>


### PR DESCRIPTION
utf-8에서 UTF-8로 바꿈
이유: UTF-8이 아닐 경우 깃헙 페이지 빌드 에러가 발생할 수 있다고 하여, 수정함